### PR TITLE
Node 버전을 16 으로 변경

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "10"
+- "16"
 jobs:
   include:
   - stage: build apiserver

--- a/packages/apiserver/Dockerfile
+++ b/packages/apiserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 ENV NODE_ENV production
 

--- a/packages/apiserver/Dockerfile-dev
+++ b/packages/apiserver/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 RUN mkdir -p /usr/src/app/apiserver
 WORKDIR /usr/src/app/apiserver

--- a/packages/apiserver/app.yaml
+++ b/packages/apiserver/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs16
 env_variables:
   NODE_TLS_REJECT_UNAUTHORIZED: '0'
   NODE_ENV: 'production'

--- a/packages/apiserver/cloudformation.yaml
+++ b/packages/apiserver/cloudformation.yaml
@@ -57,7 +57,7 @@ Resources:
       Handler: main.handler
       MemorySize: 1024
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs16.x
       Timeout: 20
       Events:
         ProxyApiRoot:

--- a/packages/apiserver/packaged-sam.yaml
+++ b/packages/apiserver/packaged-sam.yaml
@@ -61,7 +61,7 @@ Resources:
         Fn::GetAtt:
         - LambdaExecutionRole
         - Arn
-      Runtime: nodejs10.x
+      Runtime: nodejs16.x
       Timeout: 20
       Events:
         ProxyApiRoot:


### PR DESCRIPTION
Node v10 은 Lambda 지원이 종료되었습니다. 배포가 되지 않고 있어 최신 버전으로 올립니다.
